### PR TITLE
Fix removing relationship components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 - Fixes false-positive debug checks on registered queries and unsafe get (#179)
 - Fixes a bookkeeping bug when recycling relationship tables (#204)
 - Fixes garbage collected pointers when assigning components using non-`...Fn` methods (#205)
+- Fix error on removing relationship components (#212)
+- Check that entities actually have relationship components to set target for (#212)
 
 ### Other
 

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -90,7 +90,7 @@ func (a *archetype) GetTable(storage *storage, relations []RelationID) (*table, 
 	if !a.HasRelations() {
 		return &storage.tables[a.tables[0]], true
 	}
-	if len(relations) < int(a.numRelations) {
+	if uint8(len(relations)) < a.numRelations {
 		panic("relation targets must be fully specified")
 	}
 	index := a.componentsMap[relations[0].component.id]

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -90,8 +90,8 @@ func (a *archetype) GetTable(storage *storage, relations []RelationID) (*table, 
 	if !a.HasRelations() {
 		return &storage.tables[a.tables[0]], true
 	}
-	if len(relations) != int(a.numRelations) {
-		panic("relations must be fully specified")
+	if len(relations) < int(a.numRelations) {
+		panic("relation targets must be fully specified")
 	}
 	index := a.componentsMap[relations[0].component.id]
 	tables, ok := a.relationTables[index][relations[0].target.id]

--- a/ecs/map_test.go
+++ b/ecs/map_test.go
@@ -263,7 +263,7 @@ func TestMapRelation(t *testing.T) {
 			childMap.SetRelation(e, deadParent)
 		})
 	assert.PanicsWithValue(t,
-		"relations must be fully specified",
+		"relation targets must be fully specified",
 		func() {
 			childMap.NewEntity(&ChildOf{})
 		})

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -225,14 +225,13 @@ func (s *storage) createArchetype(node *node) *archetype {
 
 func (s *storage) createTable(archetype *archetype, relations []RelationID) *table {
 	targets := make([]Entity, len(archetype.components))
-	numRelations := uint8(0)
+
+	if uint8(len(relations)) < archetype.numRelations {
+		panic("relation targets must be fully specified")
+	}
 	for _, rel := range relations {
 		idx := archetype.componentsMap[rel.component.id]
 		targets[idx] = rel.target
-		numRelations++
-	}
-	if numRelations < archetype.numRelations {
-		panic("relation targets must be fully specified")
 	}
 	for i := range relations {
 		rel := &relations[i]

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -227,6 +227,7 @@ func (s *storage) createTable(archetype *archetype, relations []RelationID) *tab
 	targets := make([]Entity, len(archetype.components))
 
 	if uint8(len(relations)) < archetype.numRelations {
+		// TODO: is there way to trigger this?
 		panic("relation targets must be fully specified")
 	}
 	for _, rel := range relations {

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"fmt"
 	"unsafe"
 )
 
@@ -230,8 +231,8 @@ func (s *storage) createTable(archetype *archetype, relations []RelationID) *tab
 		targets[idx] = rel.target
 		numRelations++
 	}
-	if numRelations != archetype.numRelations {
-		panic("relations must be fully specified")
+	if numRelations < archetype.numRelations {
+		panic("relation targets must be fully specified")
 	}
 	for i := range relations {
 		rel := &relations[i]
@@ -360,6 +361,10 @@ func (s *storage) getExchangeTargets(oldTable *table, relations []RelationID) ([
 		// Validity of the target is checked when creating a new table.
 		// Whether the component is a relation is checked when creating a new table.
 		column := oldTable.components[rel.component.id]
+		if column == nil {
+			tp, _ := s.registry.ComponentType(rel.component.id)
+			panic(fmt.Sprintf("entity has no component of type %s to set relation target for", tp.Name()))
+		}
 		if rel.target == targets[column.index] {
 			continue
 		}

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -224,6 +224,7 @@ func (s *storage) createArchetype(node *node) *archetype {
 }
 
 func (s *storage) createTable(archetype *archetype, relations []RelationID) *table {
+	// TODO: maybe use a pool of slices?
 	targets := make([]Entity, len(archetype.components))
 
 	if uint8(len(relations)) < archetype.numRelations {
@@ -327,6 +328,7 @@ func (s *storage) moveEntities(src, dst *table, count uint32) {
 }
 
 func (s *storage) getExchangeTargetsUnchecked(oldTable *table, relations []RelationID) []RelationID {
+	// TODO: maybe use a pool of slices?
 	targets := make([]Entity, len(oldTable.columns))
 	for i := range oldTable.columns {
 		targets[i] = oldTable.columns[i].target
@@ -353,6 +355,7 @@ func (s *storage) getExchangeTargetsUnchecked(oldTable *table, relations []Relat
 
 func (s *storage) getExchangeTargets(oldTable *table, relations []RelationID) ([]RelationID, bool) {
 	changed := false
+	// TODO: maybe use a pool of slices?
 	targets := make([]Entity, len(oldTable.columns))
 	for i := range oldTable.columns {
 		targets[i] = oldTable.columns[i].target

--- a/ecs/table.go
+++ b/ecs/table.go
@@ -187,11 +187,16 @@ func (t *table) AddAllEntities(other *table, count uint32) {
 }
 
 func (t *table) MatchesExact(relations []RelationID) bool {
-	if len(relations) != len(t.relationIDs) {
+	if len(relations) < len(t.relationIDs) {
 		panic("relation targets must be fully specified")
 	}
 	for _, rel := range relations {
 		column := t.components[rel.component.id]
+		if column == nil {
+			// TODO: is there a check anywhere that prevents adding/setting relations
+			// on columns not in the table?
+			continue
+		}
 		if !column.isRelation {
 			panic(fmt.Sprintf("component %d is not a relation component", rel.component.id))
 		}

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -224,6 +224,12 @@ func TestWorldRelations(t *testing.T) {
 
 	e := mapper2.NewEntity(&Position{}, &ChildOf{}, RelIdx(1, parent1))
 	child2Map.Add(e, &ChildOf2{}, RelIdx(0, parent2))
+
+	child2Map.Remove(e)
+
+	assert.PanicsWithValue(t, "entity has no component of type ChildOf2 to set relation target for", func() {
+		child2Map.SetRelations(e, RelIdx(0, parent2))
+	})
 }
 
 func TestWorldSetRelations(t *testing.T) {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -225,6 +225,12 @@ func TestWorldRelations(t *testing.T) {
 	e := mapper2.NewEntity(&Position{}, &ChildOf{}, RelIdx(1, parent1))
 	child2Map.Add(e, &ChildOf2{}, RelIdx(0, parent2))
 
+	child2Map.SetRelations(e, RelIdx(0, parent1))
+	assert.Equal(t, parent1, child2Map.GetRelation(e, 0))
+
+	child2Map.SetRelations(e, RelIdx(0, parent1))
+	assert.Equal(t, parent1, child2Map.GetRelation(e, 0))
+
 	child2Map.Remove(e)
 
 	assert.PanicsWithValue(t, "entity has no component of type ChildOf2 to set relation target for", func() {


### PR DESCRIPTION
It was not possible to remove relationship components, as Ark complained "relations must be fully specified".

Further, it is checked whether entities actually have the relation component to set a target for.