### PR TITLE
Add test for copyPtr and remove unnecessary cast when calling copyPtr

### DIFF
--- a/ecs/column.go
+++ b/ecs/column.go
@@ -50,7 +50,7 @@ func (c *column) Set(index uint32, comp unsafe.Pointer) unsafe.Pointer {
 		return dst
 	}
 
-	copyPtr(comp, dst, uintptr(c.itemSize))
+	copyPtr(comp, dst, c.itemSize)
 	return dst
 }
 

--- a/ecs/util_test.go
+++ b/ecs/util_test.go
@@ -1,7 +1,9 @@
 package ecs
 
 import (
+	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -9,6 +11,48 @@ import (
 func TestTypeOf(t *testing.T) {
 	posType := typeOf[Position]()
 	assert.Equal(t, "Position", posType.Name())
+}
+
+func TestCopyPtr(t *testing.T) {
+	assert := assert.New(t)
+
+	type itemType uint8 // can be any type, result stays the same
+
+	// setup
+	var item itemType = 3
+	typeOfItem := reflect.TypeOf(item)
+	itemSize := sizeOf(typeOfItem)
+	targetItemIndex := 6
+	totalItems := 10
+	data := reflect.New(reflect.ArrayOf(int(totalItems), typeOfItem)).Elem()
+	dataPointer := data.Addr().UnsafePointer() // points to the start of data
+
+	getItem := func(index int) *itemType {
+		return (*itemType)(unsafe.Add(dataPointer, uintptr(index)*itemSize))
+	}
+
+	// check that the expected item is not there yet
+	for i := range totalItems {
+		assert.Equal(itemType(0), *getItem(i))
+	}
+
+	// copy the item to the right place
+	destination := unsafe.Add(
+		dataPointer,
+		uintptr(targetItemIndex)*itemSize,
+	)
+
+	source := unsafe.Pointer(&item)
+	copyPtr(source, destination, itemSize)
+
+	// check that only the expected item is now set
+	for i := range totalItems {
+		if i == targetItemIndex {
+			assert.Equal(item, *getItem(i))
+		} else {
+			assert.Equal(itemType(0), *getItem(i))
+		}
+	}
 }
 
 func TestPagedSlice(t *testing.T) {


### PR DESCRIPTION
I'm going to use this same copyPtr util function in my own ECS so I wrote a test to make sure it does what I expect it to do. 

Do you mind if I just include this function (but rewritten in my personal coding styling preference) in my own repo? Would you like me to credit this repo from my repo or is it not necessary? Not sure what the standard is for small util functions like this.