### PR TITLE
use reflect.TypeFor to get reflect.type of generic

### DIFF
--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -1,12 +1,15 @@
 package ecs
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"reflect"
+)
 
 type entityID uint32
 
-var entityType = typeOf[Entity]()
+var entityType = reflect.TypeFor[Entity]()
 var entitySize = sizeOf(entityType)
-var entityIndexSize = sizeOf(typeOf[entityIndex]())
+var entityIndexSize = sizeOf(reflect.TypeFor[entityIndex]())
 
 //var wildcard = Entity{1, 0}
 

--- a/ecs/functions.go
+++ b/ecs/functions.go
@@ -14,7 +14,7 @@ import "reflect"
 //
 // ⚠️ Warning: Using IDs that are outside of the range of registered IDs anywhere in [World] or other places will result in undefined behavior!
 func ComponentID[T any](w *World) ID {
-	return w.componentID(typeOf[T]())
+	return w.componentID(reflect.TypeFor[T]())
 }
 
 // ComponentIDs returns a list of all registered component IDs.
@@ -57,7 +57,7 @@ type Comp struct {
 
 // C creates a [Comp] instance for the given type.
 func C[T any]() Comp {
-	return Comp{typeOf[T]()}
+	return Comp{reflect.TypeFor[T]()}
 }
 
 // Type returns the reflect.Type of the component.
@@ -70,7 +70,7 @@ func (c Comp) Type() reflect.Type {
 //
 // The number of resources per [World] is limited to 256 (64 with build tag tiny).
 func ResourceID[T any](w *World) ResID {
-	return w.resourceID(typeOf[T]())
+	return w.resourceID(reflect.TypeFor[T]())
 }
 
 // ResourceIDs returns a list of all registered resource IDs.

--- a/ecs/functions_test.go
+++ b/ecs/functions_test.go
@@ -74,14 +74,14 @@ func TestComponentInfo(t *testing.T) {
 
 func TestCompType(t *testing.T) {
 	c := C[Position]()
-	assert.Equal(t, typeOf[Position](), c.Type())
+	assert.Equal(t, reflect.TypeFor[Position](), c.Type())
 }
 
 func TestResourceTypeID(t *testing.T) {
 	w := NewWorld(1024)
-	id1 := ResourceTypeID(&w, typeOf[Position]())
-	id2 := ResourceTypeID(&w, typeOf[Velocity]())
-	id3 := ResourceTypeID(&w, typeOf[Position]())
+	id1 := ResourceTypeID(&w, reflect.TypeFor[Position]())
+	id2 := ResourceTypeID(&w, reflect.TypeFor[Velocity]())
+	id3 := ResourceTypeID(&w, reflect.TypeFor[Position]())
 
 	assert.EqualValues(t, 0, id1.id)
 	assert.EqualValues(t, 1, id2.id)

--- a/ecs/registry_test.go
+++ b/ecs/registry_test.go
@@ -56,8 +56,8 @@ func BenchmarkRegistryGet(b *testing.B) {
 }
 
 func BenchmarkTypeEquality(b *testing.B) {
-	tp1 := typeOf[Position]()
-	tp2 := typeOf[Velocity]()
+	tp1 := reflect.TypeFor[Position]()
+	tp2 := reflect.TypeFor[Velocity]()
 
 	for b.Loop() {
 		_ = tp1 == tp2

--- a/ecs/relation.go
+++ b/ecs/relation.go
@@ -1,6 +1,8 @@
 package ecs
 
-var relationTp = typeOf[RelationMarker]()
+import "reflect"
+
+var relationTp = reflect.TypeFor[RelationMarker]()
 
 // RelationMarker is a marker for entity relation components.
 // It must be embedded as first field of a component that represent an entity relationship

--- a/ecs/util.go
+++ b/ecs/util.go
@@ -16,10 +16,6 @@ func copyPtr(src, dst unsafe.Pointer, itemSize uintptr) {
 	copy(dstSlice, srcSlice)
 }
 
-func typeOf[T any]() reflect.Type {
-	return reflect.TypeFor[T]()
-}
-
 func sizeOf(tp reflect.Type) uintptr {
 	size, align := tp.Size(), uintptr(tp.Align())
 	return (size + (align - 1)) / align * align

--- a/ecs/util.go
+++ b/ecs/util.go
@@ -17,7 +17,7 @@ func copyPtr(src, dst unsafe.Pointer, itemSize uintptr) {
 }
 
 func typeOf[T any]() reflect.Type {
-	return reflect.TypeOf((*T)(nil)).Elem()
+	return reflect.TypeFor[T]()
 }
 
 func sizeOf(tp reflect.Type) uintptr {

--- a/ecs/util_test.go
+++ b/ecs/util_test.go
@@ -8,11 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTypeOf(t *testing.T) {
-	posType := typeOf[Position]()
-	assert.Equal(t, "Position", posType.Name())
-}
-
 func TestCopyPtr(t *testing.T) {
 	assert := assert.New(t)
 
@@ -69,14 +64,8 @@ func TestPagedSlice(t *testing.T) {
 	assert.Equal(t, int32(100), *a.Get(3))
 }
 
-func BenchmarkTypeOf(b *testing.B) {
-	for b.Loop() {
-		_ = typeOf[Position]()
-	}
-}
-
 func BenchmarkSizeOf(b *testing.B) {
-	tp := typeOf[Position]()
+	tp := reflect.TypeFor[Position]()
 	for b.Loop() {
 		_ = sizeOf(tp)
 	}


### PR DESCRIPTION
Get types of a generic using reflect.TypeFor. This does a similar trick, but first attempts to create an instance of the generic
```
var v T
if t := TypeOf(v); t != nil {
	return t // optimize for T being a non-interface kind
}
return TypeOf((*T)(nil)).Elem() // <-- this is the trick that we were using before
```

Getting the type of a generic is now about 30% faster. Running the benchmarks (`go test -bench=.  ./...`), I've seen a nice performance boost of about 5% in some of the tests. I think you're a bit more familiar with the benchmarks, so please let me know what differences you see!  

Since the `typeOf` function is now just a wrapper for a `reflect.TypeFor`, it can also be removed all together if you'd prefer that. 