### PR TITLE
Use faster pointer copying for trivial component types

### DIFF
--- a/ecs/map_test.go
+++ b/ecs/map_test.go
@@ -238,7 +238,7 @@ func TestMapSliceComponent(t *testing.T) {
 
 	cnt := 0
 	sliceMap.NewBatchFn(n, func(entity Entity, sl *SliceComp) {
-		sl.Slice = []int{1, 2, 3, 4}
+		sl.Slice = []int{cnt + 1, cnt + 2, cnt + 3, cnt + 4}
 		cnt++
 	})
 	assert.Equal(t, n, cnt)
@@ -255,7 +255,7 @@ func TestMapSliceComponent(t *testing.T) {
 	cnt = 0
 	for query.Next() {
 		sl := query.Get()
-		assert.EqualValues(t, []int{1, 2, 3, 4}, sl.Slice)
+		assert.EqualValues(t, []int{cnt + 1, cnt + 2, cnt + 3, cnt + 4}, sl.Slice)
 		cnt++
 	}
 	assert.Equal(t, n, cnt)

--- a/ecs/map_test.go
+++ b/ecs/map_test.go
@@ -229,6 +229,38 @@ func TestMapAddBatchFn(t *testing.T) {
 	assert.Equal(t, 0, cnt)
 }
 
+func TestMapSliceComponent(t *testing.T) {
+	n := 12
+	w := NewWorld(8)
+
+	mapper := NewMap[CompA](&w)
+	sliceMap := NewMap[SliceComp](&w)
+
+	cnt := 0
+	sliceMap.NewBatchFn(n, func(entity Entity, sl *SliceComp) {
+		sl.Slice = []int{1, 2, 3, 4}
+		cnt++
+	})
+	assert.Equal(t, n, cnt)
+
+	filter := NewFilter1[SliceComp](&w)
+	cnt = 0
+	mapper.AddBatchFn(filter.Batch(), func(entity Entity, a *CompA) {
+		a.X = float64(cnt)
+		cnt++
+	})
+
+	filter2 := NewFilter1[SliceComp](&w)
+	query := filter2.Query()
+	cnt = 0
+	for query.Next() {
+		sl := query.Get()
+		assert.EqualValues(t, []int{1, 2, 3, 4}, sl.Slice)
+		cnt++
+	}
+	assert.Equal(t, n, cnt)
+}
+
 func TestMapRelation(t *testing.T) {
 	w := NewWorld(32)
 

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -96,7 +96,7 @@ func (s *storage) RemoveEntity(entity Entity) {
 	index := &s.entities[entity.id]
 	table := &s.tables[index.table]
 
-	swapped := table.Remove(index.row)
+	swapped := table.Remove(index.row, &s.registry)
 
 	s.entityPool.Recycle(entity)
 
@@ -318,7 +318,7 @@ func (s *storage) cleanupArchetypes(target Entity) {
 // moveEntities moves all entities from src to dst.
 func (s *storage) moveEntities(src, dst *table, count uint32) {
 	oldLen := dst.Len()
-	dst.AddAll(src, count)
+	dst.AddAll(src, count, &s.registry)
 
 	newLen := dst.Len()
 	newTable := dst.id

--- a/ecs/util.go
+++ b/ecs/util.go
@@ -39,6 +39,51 @@ func appendNew[T any](sl []T, elems ...T) []T {
 	return sl2
 }
 
+// isRelation determines whether a type is a relation component.
+func isRelation(tp reflect.Type) bool {
+	if tp.Kind() != reflect.Struct || tp.NumField() == 0 {
+		return false
+	}
+	field := tp.Field(0)
+	return field.Type == relationTp && field.Name == relationTp.Name()
+}
+
+// isTrivial checks if a type is "trivial" (contains no pointers, slices, maps, or channels).
+// It also returns false if the type itself is one of these.
+func isTrivial(tp reflect.Type) bool {
+	// Base case: If the type is invalid, return false
+	if tp == nil {
+		return false
+	}
+
+	// Check if the type itself is a pointer, slice, map, or channel
+	switch tp.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Chan, reflect.Interface:
+		return false
+	}
+
+	// If it's a struct, check its fields recursively
+	if tp.Kind() == reflect.Struct {
+		for i := 0; i < tp.NumField(); i++ {
+			field := tp.Field(i).Type
+			if !isTrivial(field) {
+				return false
+			}
+		}
+	}
+
+	// If it's an array, check its elements recursively
+	if tp.Kind() == reflect.Array {
+		elemType := tp.Elem()
+		if !isTrivial(elemType) {
+			return false
+		}
+	}
+
+	// If none of the above conditions matched, it's trivial
+	return true
+}
+
 // pagedSlice is a paged collection working with pages of length 32 slices.
 // its primary purpose is pointer persistence, which is not given using simple slices.
 //

--- a/ecs/util.go
+++ b/ecs/util.go
@@ -48,7 +48,7 @@ func isRelation(tp reflect.Type) bool {
 	return field.Type == relationTp && field.Name == relationTp.Name()
 }
 
-// isTrivial checks if a type is "trivial" (contains no pointers, slices, maps, or channels).
+// isTrivial checks if a type is "trivial" (contains no pointers, slices, maps, strings, or channels).
 // It also returns false if the type itself is one of these.
 func isTrivial(tp reflect.Type) bool {
 	// Base case: If the type is invalid, return false
@@ -58,7 +58,7 @@ func isTrivial(tp reflect.Type) bool {
 
 	// Check if the type itself is a pointer, slice, map, or channel
 	switch tp.Kind() {
-	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Chan, reflect.Interface:
+	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Chan, reflect.Interface, reflect.String:
 		return false
 	}
 

--- a/ecs/util_test.go
+++ b/ecs/util_test.go
@@ -64,6 +64,33 @@ func TestPagedSlice(t *testing.T) {
 	assert.Equal(t, int32(100), *a.Get(3))
 }
 
+func TestIsTrivial(t *testing.T) {
+	assert.True(t, isTrivial(reflect.TypeFor[[5]int]()))
+	assert.True(t, isTrivial(reflect.TypeFor[struct{}]()))
+	assert.True(t, isTrivial(reflect.TypeFor[struct {
+		A int
+	}]()))
+	assert.True(t, isTrivial(reflect.TypeFor[struct {
+		A struct{ A int }
+	}]()))
+
+	assert.False(t, isTrivial(reflect.TypeFor[[]int]()))
+	assert.False(t, isTrivial(reflect.TypeFor[[5]string]()))
+
+	assert.False(t, isTrivial(reflect.TypeFor[struct {
+		S []int
+	}]()))
+	assert.False(t, isTrivial(reflect.TypeFor[struct {
+		S []string
+	}]()))
+	assert.False(t, isTrivial(reflect.TypeFor[struct {
+		S [5]string
+	}]()))
+	assert.False(t, isTrivial(reflect.TypeFor[struct {
+		A struct{ S string }
+	}]()))
+}
+
 func BenchmarkSizeOf(b *testing.B) {
 	tp := reflect.TypeFor[Position]()
 	for b.Loop() {

--- a/ecs/util_test.go
+++ b/ecs/util_test.go
@@ -74,6 +74,7 @@ func TestIsTrivial(t *testing.T) {
 		A struct{ A int }
 	}]()))
 
+	assert.False(t, isTrivial(nil))
 	assert.False(t, isTrivial(reflect.TypeFor[[]int]()))
 	assert.False(t, isTrivial(reflect.TypeFor[[5]string]()))
 

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -50,11 +50,11 @@ func (w *World) exchange(entity Entity, add []ID, rem []ID, relations []Relation
 
 	for _, id := range oldArchetype.components {
 		if mask.Get(id) {
-			newTable.Set(id, newIndex, oldTable.Column(id), int(index.row))
+			newTable.Set(id, newIndex, oldTable.Column(id), int(index.row), w.storage.registry.IsTrivial[id.id])
 		}
 	}
 
-	swapped := oldTable.Remove(index.row)
+	swapped := oldTable.Remove(index.row, &w.storage.registry)
 
 	if swapped {
 		swapEntity := oldTable.GetEntity(uintptr(index.row))
@@ -126,7 +126,7 @@ func (w *World) exchangeTable(oldTable *table, oldLen int, add []ID, rem []ID, r
 		if mask.Get(id) {
 			oldCol := oldTable.GetColumn(id)
 			newCol := newTable.GetColumn(id)
-			newCol.SetLast(oldCol, newTable.len, uint32(oldLen))
+			newCol.SetLast(oldCol, newTable.len, uint32(oldLen), w.storage.registry.IsTrivial[id.id])
 		}
 	}
 
@@ -165,10 +165,10 @@ func (w *World) setRelations(entity Entity, relations []RelationID) {
 	newIndex := newTable.Add(entity)
 
 	for _, id := range oldArch.components {
-		newTable.Set(id, newIndex, oldTable.Column(id), int(index.row))
+		newTable.Set(id, newIndex, oldTable.Column(id), int(index.row), w.storage.registry.IsTrivial[id.id])
 	}
 
-	swapped := oldTable.Remove(index.row)
+	swapped := oldTable.Remove(index.row, &w.storage.registry)
 
 	if swapped {
 		swapEntity := oldTable.GetEntity(uintptr(index.row))

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -554,7 +554,10 @@ func TestWorldCreateManyTablesSlice(t *testing.T) {
 
 	entities := make([]Entity, 0)
 	for range n {
-		entities = append(entities, dataMap.NewEntity(&SliceComp{Slice: []int{1, 2, 3, 4}}))
+		e := dataMap.NewEntity(&SliceComp{Slice: nil})
+		sl := dataMap.Get(e)
+		sl.Slice = []int{int(e.id) + 1, int(e.id) + 2, int(e.id) + 3, int(e.id) + 4}
+		entities = append(entities, e)
 	}
 
 	filter := NewFilter1[SliceComp](&w)
@@ -576,6 +579,7 @@ func TestWorldCreateManyTablesSlice(t *testing.T) {
 	assert.Equal(t, n, q.Count())
 	for q.Next() {
 		sl := q.Get()
-		assert.Equal(t, []int{1, 2, 3, 4}, sl.Slice)
+		e := q.Entity()
+		assert.Equal(t, []int{int(e.id) + 1, int(e.id) + 2, int(e.id) + 3, int(e.id) + 4}, sl.Slice)
 	}
 }

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -520,6 +520,9 @@ func TestWorldCreateManyTables(t *testing.T) {
 	w := NewWorld()
 	dataMap := NewMap1[Position](&w)
 
+	id := ComponentID[Position](&w)
+	assert.True(t, w.storage.registry.IsTrivial[id.id])
+
 	entities := make([]Entity, 0)
 	for i := range n {
 		entities = append(entities, dataMap.NewEntity(&Position{X: float64(i)}))
@@ -545,6 +548,9 @@ func TestWorldCreateManyTablesSlice(t *testing.T) {
 
 	w := NewWorld()
 	dataMap := NewMap1[SliceComp](&w)
+
+	id := ComponentID[SliceComp](&w)
+	assert.False(t, w.storage.registry.IsTrivial[id.id])
 
 	entities := make([]Entity, 0)
 	for range n {


### PR DESCRIPTION
Keep performance up while fixing #246 