### PR TITLE
Fix: Duplicate results after removing one related entity and adding another (stale relationTables entries for freed table)

### DIFF
--- a/ecs/relation_test.go
+++ b/ecs/relation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRel(t *testing.T) {
@@ -95,4 +96,56 @@ func TestRemoveRelationTarget(t *testing.T) {
 	world.RemoveEntity(e2)
 	assert.Equal(t, Entity{}, childMap.GetRelation(e3))
 	assert.Equal(t, Entity{}, child2Map.GetRelation(e3))
+}
+
+func TestMultiRelation_RemoveAndReAdd_NoDuplicates(t *testing.T) {
+	world := NewWorld()
+
+	f := func(t *testing.T, world *World) {
+		e1 := world.NewEntity()
+		e2 := world.NewEntity()
+
+		gen := NewMap3[Position, ChildOf, ChildOf2](world)
+		e3 := gen.NewEntity(
+			&Position{},
+			&ChildOf{}, &ChildOf2{},
+			RelIdx(1, e1), RelIdx(2, e2),
+		)
+
+		filter := NewFilter1[Position](world)
+
+		check := func(prefix string, rel Relation, wanted ...Entity) {
+			var entities = make(map[Entity]bool)
+			for query := filter.Query(rel); query.Next(); {
+				entity := query.Entity()
+				require.False(t, entities[entity], "%s: entity %v returned multiple times", prefix, entity)
+				entities[entity] = true
+			}
+			for _, w := range wanted {
+				require.True(t, entities[w], "%s: entity %v not returned", prefix, w)
+				delete(entities, w)
+			}
+			require.Empty(t, entities, "%s: unexpected entities returned: %v", prefix, entities)
+		}
+
+		check("initial, query by ChildOf", Rel[ChildOf](e1), e3)
+		check("initial, query by ChildOf2", Rel[ChildOf2](e2), e3)
+
+		world.RemoveEntity(e1)
+
+		check("after removing e1, query by ChildOf2", Rel[ChildOf2](e2), e3)
+
+		e4 := world.NewEntity()
+		e5 := gen.NewEntity(
+			&Position{},
+			&ChildOf{}, &ChildOf2{},
+			RelIdx(1, e4), RelIdx(2, e2),
+		)
+		check("after adding e5, query by ChildOf", Rel[ChildOf](e4), e5)
+		check("after adding e5, query by ChildOf2", Rel[ChildOf2](e2), e3, e5)
+	}
+
+	t.Run("fresh world", func(t *testing.T) { f(t, &world) })
+	world.Reset()
+	t.Run("after reset", func(t *testing.T) { f(t, &world) })
 }

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -306,7 +306,7 @@ func (s *storage) cleanupArchetypes(target Entity) {
 				}
 				s.moveEntities(table, newTable, uint32(table.Len()))
 			}
-			archetype.FreeTable(table.id)
+			archetype.FreeTable(table, false)
 			s.cache.removeTable(s, table)
 
 			newRelations = newRelations[:0]


### PR DESCRIPTION
# Summary

Fixes #263  a bug where querying by a relation target could return duplicate entities after:

1. Creating an entity with multiple relations,
2. Removing one of the related entities, and
3. Adding a new entity that reuses the remaining relation.

# Cause
Freed tables were still referenced in relationTables, leading to stale entries and duplicate query results.

# Fix

- Updated FreeTable to unindex tables from relationTables using table.relationIDs.
- Skip unindexing only in Reset, since relationTables are cleared afterwards.

# Tests
Added regression test TestMultiRelation_RemoveAndReAdd_NoDuplicates, which:
- Ensures no duplicates after remove+add sequence.
- Runs both in a fresh world and after World.Reset().