### PR TITLE
Auto-select rare component for archetype pre-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Performance
 
-- Adds a mapping from components to archetypes to speed up queries in case of many archetypes (#269)
+- Adds a mapping from components to archetypes to speed up queries in case of many archetypes (#269, #271)
 
 ### Documentation
 

--- a/docs/content/performance/index.md
+++ b/docs/content/performance/index.md
@@ -38,12 +38,6 @@ A good (or rather, bad) example is a `Tree` component with `X`, `Y`, `Biomass`, 
 
 For fast memory access, the use of slices in components should be avoided. Use fixed-size arrays where possible.
 
-## Component order in queries
-
-Ark accelerates queries by maintaining a mapping from each component to the set of archetypes that include it. This can reduce the number of archetypes a query needs to scan significantly, especially in worlds with a high number of archetypes.
-
-To maximize query performance, order your query parameters strategically: place the rarest component last. In this context, "rare" refers to components that appear in the fewest number of archetypes. By filtering with the most selective component at the end, Ark can narrow down the candidate archetypes most efficiently.
-
 ## Filter caching
 
 When working with many [archetypes](../architecture), queries can be sped up by caching the underlying filter.

--- a/docs/content/queries/index.md
+++ b/docs/content/queries/index.md
@@ -33,15 +33,12 @@ This has two reasons.
 Firstly, all entities with the same component composition are stored in the same archetype, or "table".
 This means that filters only need to be checked against archetypes,
 and the entities of a matching archetype can be iterated without any further checks.
+Further, Ark maintains a mapping from each component to the set of archetypes that include it.
+This is used to reduce the number of filter checks by pre-selecting archetypes by the most "rare" component of a query.
 
 Secondly, all components of the same type (like `Position`) are stored in a dedicated column of the archetype.
 A query only accesses the required components (i.e. columns), although entities may possess many more components.
 Memory access is therefore completely linear and contiguous, and the CPUs cache is used as efficiently as possible.
-
-> [!TIP]
-> To maximize query performance, order your query parameters strategically:
-> place the rarest component last.
-> See the chapter on [Performance tips](../performance#component-order-in-queries) for details.
 
 ## World lock
 

--- a/ecs/filter_gen.go
+++ b/ecs/filter_gen.go
@@ -9,12 +9,13 @@ package ecs
 //
 // See [Filter2] for a usage example.
 type Filter0 struct {
-	world        *World
-	ids          []ID
-	relations    []RelationID
-	components   []*componentStorage
-	filter       filter
-	cache        cacheID
+	world      *World
+	ids        []ID
+	relations  []RelationID
+	components []*componentStorage
+	filter     filter
+	cache      cacheID
+
 	numRelations uint8
 }
 
@@ -172,6 +173,8 @@ type Filter1[A any] struct {
 	components   []*componentStorage
 	filter       filter
 	cache        cacheID
+	rareComp     uint8
+	generation   int
 	numRelations uint8
 }
 
@@ -302,7 +305,7 @@ func (f *Filter1[A]) Query(rel ...Relation) Query1[A] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		rareComp: f.ids[0].id,
+		rareComp: f.rareComp,
 	}
 }
 
@@ -344,6 +347,8 @@ type Filter2[A any, B any] struct {
 	components   []*componentStorage
 	filter       filter
 	cache        cacheID
+	rareComp     uint8
+	generation   int
 	numRelations uint8
 }
 
@@ -458,6 +463,12 @@ func (f *Filter2[A, B]) Query(rel ...Relation) Query2[A, B] {
 	var cache *cacheEntry
 	if f.cache != maxCacheID {
 		cache = f.world.storage.getRegisteredFilter(f.cache)
+	} else {
+		reg := &f.world.storage.registry
+		if f.generation != reg.getGeneration() {
+			f.rareComp = reg.rareComponent(f.ids).id
+			f.generation = reg.getGeneration()
+		}
 	}
 
 	return Query2[A, B]{
@@ -473,7 +484,7 @@ func (f *Filter2[A, B]) Query(rel ...Relation) Query2[A, B] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
+		rareComp: f.rareComp,
 	}
 }
 
@@ -517,6 +528,8 @@ type Filter3[A any, B any, C any] struct {
 	components   []*componentStorage
 	filter       filter
 	cache        cacheID
+	rareComp     uint8
+	generation   int
 	numRelations uint8
 }
 
@@ -634,6 +647,12 @@ func (f *Filter3[A, B, C]) Query(rel ...Relation) Query3[A, B, C] {
 	var cache *cacheEntry
 	if f.cache != maxCacheID {
 		cache = f.world.storage.getRegisteredFilter(f.cache)
+	} else {
+		reg := &f.world.storage.registry
+		if f.generation != reg.getGeneration() {
+			f.rareComp = reg.rareComponent(f.ids).id
+			f.generation = reg.getGeneration()
+		}
 	}
 
 	return Query3[A, B, C]{
@@ -649,7 +668,7 @@ func (f *Filter3[A, B, C]) Query(rel ...Relation) Query3[A, B, C] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
+		rareComp: f.rareComp,
 	}
 }
 
@@ -693,6 +712,8 @@ type Filter4[A any, B any, C any, D any] struct {
 	components   []*componentStorage
 	filter       filter
 	cache        cacheID
+	rareComp     uint8
+	generation   int
 	numRelations uint8
 }
 
@@ -811,6 +832,12 @@ func (f *Filter4[A, B, C, D]) Query(rel ...Relation) Query4[A, B, C, D] {
 	var cache *cacheEntry
 	if f.cache != maxCacheID {
 		cache = f.world.storage.getRegisteredFilter(f.cache)
+	} else {
+		reg := &f.world.storage.registry
+		if f.generation != reg.getGeneration() {
+			f.rareComp = reg.rareComponent(f.ids).id
+			f.generation = reg.getGeneration()
+		}
 	}
 
 	return Query4[A, B, C, D]{
@@ -826,7 +853,7 @@ func (f *Filter4[A, B, C, D]) Query(rel ...Relation) Query4[A, B, C, D] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
+		rareComp: f.rareComp,
 	}
 }
 
@@ -870,6 +897,8 @@ type Filter5[A any, B any, C any, D any, E any] struct {
 	components   []*componentStorage
 	filter       filter
 	cache        cacheID
+	rareComp     uint8
+	generation   int
 	numRelations uint8
 }
 
@@ -989,6 +1018,12 @@ func (f *Filter5[A, B, C, D, E]) Query(rel ...Relation) Query5[A, B, C, D, E] {
 	var cache *cacheEntry
 	if f.cache != maxCacheID {
 		cache = f.world.storage.getRegisteredFilter(f.cache)
+	} else {
+		reg := &f.world.storage.registry
+		if f.generation != reg.getGeneration() {
+			f.rareComp = reg.rareComponent(f.ids).id
+			f.generation = reg.getGeneration()
+		}
 	}
 
 	return Query5[A, B, C, D, E]{
@@ -1004,7 +1039,7 @@ func (f *Filter5[A, B, C, D, E]) Query(rel ...Relation) Query5[A, B, C, D, E] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
+		rareComp: f.rareComp,
 	}
 }
 
@@ -1048,6 +1083,8 @@ type Filter6[A any, B any, C any, D any, E any, F any] struct {
 	components   []*componentStorage
 	filter       filter
 	cache        cacheID
+	rareComp     uint8
+	generation   int
 	numRelations uint8
 }
 
@@ -1168,6 +1205,12 @@ func (f *Filter6[A, B, C, D, E, F]) Query(rel ...Relation) Query6[A, B, C, D, E,
 	var cache *cacheEntry
 	if f.cache != maxCacheID {
 		cache = f.world.storage.getRegisteredFilter(f.cache)
+	} else {
+		reg := &f.world.storage.registry
+		if f.generation != reg.getGeneration() {
+			f.rareComp = reg.rareComponent(f.ids).id
+			f.generation = reg.getGeneration()
+		}
 	}
 
 	return Query6[A, B, C, D, E, F]{
@@ -1183,7 +1226,7 @@ func (f *Filter6[A, B, C, D, E, F]) Query(rel ...Relation) Query6[A, B, C, D, E,
 			index:     0,
 			maxIndex:  -1,
 		},
-		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
+		rareComp: f.rareComp,
 	}
 }
 
@@ -1227,6 +1270,8 @@ type Filter7[A any, B any, C any, D any, E any, F any, G any] struct {
 	components   []*componentStorage
 	filter       filter
 	cache        cacheID
+	rareComp     uint8
+	generation   int
 	numRelations uint8
 }
 
@@ -1348,6 +1393,12 @@ func (f *Filter7[A, B, C, D, E, F, G]) Query(rel ...Relation) Query7[A, B, C, D,
 	var cache *cacheEntry
 	if f.cache != maxCacheID {
 		cache = f.world.storage.getRegisteredFilter(f.cache)
+	} else {
+		reg := &f.world.storage.registry
+		if f.generation != reg.getGeneration() {
+			f.rareComp = reg.rareComponent(f.ids).id
+			f.generation = reg.getGeneration()
+		}
 	}
 
 	return Query7[A, B, C, D, E, F, G]{
@@ -1363,7 +1414,7 @@ func (f *Filter7[A, B, C, D, E, F, G]) Query(rel ...Relation) Query7[A, B, C, D,
 			index:     0,
 			maxIndex:  -1,
 		},
-		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
+		rareComp: f.rareComp,
 	}
 }
 
@@ -1407,6 +1458,8 @@ type Filter8[A any, B any, C any, D any, E any, F any, G any, H any] struct {
 	components   []*componentStorage
 	filter       filter
 	cache        cacheID
+	rareComp     uint8
+	generation   int
 	numRelations uint8
 }
 
@@ -1529,6 +1582,12 @@ func (f *Filter8[A, B, C, D, E, F, G, H]) Query(rel ...Relation) Query8[A, B, C,
 	var cache *cacheEntry
 	if f.cache != maxCacheID {
 		cache = f.world.storage.getRegisteredFilter(f.cache)
+	} else {
+		reg := &f.world.storage.registry
+		if f.generation != reg.getGeneration() {
+			f.rareComp = reg.rareComponent(f.ids).id
+			f.generation = reg.getGeneration()
+		}
 	}
 
 	return Query8[A, B, C, D, E, F, G, H]{
@@ -1544,7 +1603,7 @@ func (f *Filter8[A, B, C, D, E, F, G, H]) Query(rel ...Relation) Query8[A, B, C,
 			index:     0,
 			maxIndex:  -1,
 		},
-		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
+		rareComp: f.rareComp,
 	}
 }
 

--- a/ecs/filter_gen.go
+++ b/ecs/filter_gen.go
@@ -302,7 +302,7 @@ func (f *Filter1[A]) Query(rel ...Relation) Query1[A] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		lastComp: f.ids[len(f.ids)-1].id,
+		rareComp: f.ids[0].id,
 	}
 }
 
@@ -473,7 +473,7 @@ func (f *Filter2[A, B]) Query(rel ...Relation) Query2[A, B] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		lastComp: f.ids[len(f.ids)-1].id,
+		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
 	}
 }
 
@@ -649,7 +649,7 @@ func (f *Filter3[A, B, C]) Query(rel ...Relation) Query3[A, B, C] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		lastComp: f.ids[len(f.ids)-1].id,
+		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
 	}
 }
 
@@ -826,7 +826,7 @@ func (f *Filter4[A, B, C, D]) Query(rel ...Relation) Query4[A, B, C, D] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		lastComp: f.ids[len(f.ids)-1].id,
+		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
 	}
 }
 
@@ -1004,7 +1004,7 @@ func (f *Filter5[A, B, C, D, E]) Query(rel ...Relation) Query5[A, B, C, D, E] {
 			index:     0,
 			maxIndex:  -1,
 		},
-		lastComp: f.ids[len(f.ids)-1].id,
+		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
 	}
 }
 
@@ -1183,7 +1183,7 @@ func (f *Filter6[A, B, C, D, E, F]) Query(rel ...Relation) Query6[A, B, C, D, E,
 			index:     0,
 			maxIndex:  -1,
 		},
-		lastComp: f.ids[len(f.ids)-1].id,
+		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
 	}
 }
 
@@ -1363,7 +1363,7 @@ func (f *Filter7[A, B, C, D, E, F, G]) Query(rel ...Relation) Query7[A, B, C, D,
 			index:     0,
 			maxIndex:  -1,
 		},
-		lastComp: f.ids[len(f.ids)-1].id,
+		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
 	}
 }
 
@@ -1544,7 +1544,7 @@ func (f *Filter8[A, B, C, D, E, F, G, H]) Query(rel ...Relation) Query8[A, B, C,
 			index:     0,
 			maxIndex:  -1,
 		},
-		lastComp: f.ids[len(f.ids)-1].id,
+		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
 	}
 }
 

--- a/ecs/generate/filter.go.template
+++ b/ecs/generate/filter.go.template
@@ -27,6 +27,10 @@ type Filter{{.}}{{$generics}} struct {
 	components    []*componentStorage
 	filter        filter
 	cache         cacheID
+	{{if ne . 0 -}}
+	rareComp      uint8
+	generation    int
+	{{- end}}
 	numRelations  uint8
 }
 
@@ -149,6 +153,14 @@ func (f *Filter{{.}}{{$genericsShort}}) Query(rel ...Relation) Query{{.}}{{$gene
 	if f.cache != maxCacheID {
 		cache = f.world.storage.getRegisteredFilter(f.cache)
 	}
+	{{- if gt . 1}} else {
+		reg := &f.world.storage.registry
+		if f.generation != reg.getGeneration() {
+			f.rareComp = reg.rareComponent(f.ids).id
+			f.generation = reg.getGeneration()
+		}
+	}
+	{{- end}}
 
 	return Query{{.}}{{$genericsShort}}{
 		world:      f.world,
@@ -164,11 +176,7 @@ func (f *Filter{{.}}{{$genericsShort}}) Query(rel ...Relation) Query{{.}}{{$gene
 			maxIndex:  -1,
 		},
 		{{if ne . 0 -}}
-		{{if eq . 1 -}}
-		rareComp: f.ids[0].id,
-		{{- else -}}
-		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
-		{{- end}}
+		rareComp: f.rareComp,
 		{{- end}}
 	}
 }

--- a/ecs/generate/filter.go.template
+++ b/ecs/generate/filter.go.template
@@ -164,7 +164,11 @@ func (f *Filter{{.}}{{$genericsShort}}) Query(rel ...Relation) Query{{.}}{{$gene
 			maxIndex:  -1,
 		},
 		{{if ne . 0 -}}
-		lastComp: f.ids[len(f.ids)-1].id,
+		{{if eq . 1 -}}
+		rareComp: f.ids[0].id,
+		{{- else -}}
+		rareComp: f.world.storage.registry.rareComponent(f.ids).id,
+		{{- end}}
 		{{- end}}
 	}
 }

--- a/ecs/generate/query.go.template
+++ b/ecs/generate/query.go.template
@@ -46,7 +46,7 @@ type Query{{.}}{{$generics}} struct {
 	cursor     cursor
 	lock       uint8
 	{{if ne . 0 -}}
-	lastComp  uint8
+	rareComp  uint8
 	{{- end}}
 }
 
@@ -101,7 +101,7 @@ func (q *Query{{.}}{{$genericsShort}}) nextArchetype() bool {
 	{{if eq . 0 -}}
 	archetypes := q.world.storage.archetypes
 	{{- else -}}
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	{{- end}}
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {

--- a/ecs/query_gen.go
+++ b/ecs/query_gen.go
@@ -137,7 +137,7 @@ type Query1[A any] struct {
 	components []*componentStorage
 	cursor     cursor
 	lock       uint8
-	lastComp   uint8
+	rareComp   uint8
 }
 
 // GetRelation returns the entity relation target of the component at the given index.
@@ -184,7 +184,7 @@ func (q *Query1[A]) nextTableOrArchetype() bool {
 
 func (q *Query1[A]) nextArchetype() bool {
 	q.tables = nil
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {
 		q.cursor.archetype++
@@ -256,7 +256,7 @@ type Query2[A any, B any] struct {
 	components []*componentStorage
 	cursor     cursor
 	lock       uint8
-	lastComp   uint8
+	rareComp   uint8
 }
 
 // GetRelation returns the entity relation target of the component at the given index.
@@ -304,7 +304,7 @@ func (q *Query2[A, B]) nextTableOrArchetype() bool {
 
 func (q *Query2[A, B]) nextArchetype() bool {
 	q.tables = nil
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {
 		q.cursor.archetype++
@@ -380,7 +380,7 @@ type Query3[A any, B any, C any] struct {
 	components []*componentStorage
 	cursor     cursor
 	lock       uint8
-	lastComp   uint8
+	rareComp   uint8
 }
 
 // GetRelation returns the entity relation target of the component at the given index.
@@ -429,7 +429,7 @@ func (q *Query3[A, B, C]) nextTableOrArchetype() bool {
 
 func (q *Query3[A, B, C]) nextArchetype() bool {
 	q.tables = nil
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {
 		q.cursor.archetype++
@@ -507,7 +507,7 @@ type Query4[A any, B any, C any, D any] struct {
 	components []*componentStorage
 	cursor     cursor
 	lock       uint8
-	lastComp   uint8
+	rareComp   uint8
 }
 
 // GetRelation returns the entity relation target of the component at the given index.
@@ -557,7 +557,7 @@ func (q *Query4[A, B, C, D]) nextTableOrArchetype() bool {
 
 func (q *Query4[A, B, C, D]) nextArchetype() bool {
 	q.tables = nil
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {
 		q.cursor.archetype++
@@ -637,7 +637,7 @@ type Query5[A any, B any, C any, D any, E any] struct {
 	components []*componentStorage
 	cursor     cursor
 	lock       uint8
-	lastComp   uint8
+	rareComp   uint8
 }
 
 // GetRelation returns the entity relation target of the component at the given index.
@@ -688,7 +688,7 @@ func (q *Query5[A, B, C, D, E]) nextTableOrArchetype() bool {
 
 func (q *Query5[A, B, C, D, E]) nextArchetype() bool {
 	q.tables = nil
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {
 		q.cursor.archetype++
@@ -770,7 +770,7 @@ type Query6[A any, B any, C any, D any, E any, F any] struct {
 	components []*componentStorage
 	cursor     cursor
 	lock       uint8
-	lastComp   uint8
+	rareComp   uint8
 }
 
 // GetRelation returns the entity relation target of the component at the given index.
@@ -822,7 +822,7 @@ func (q *Query6[A, B, C, D, E, F]) nextTableOrArchetype() bool {
 
 func (q *Query6[A, B, C, D, E, F]) nextArchetype() bool {
 	q.tables = nil
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {
 		q.cursor.archetype++
@@ -906,7 +906,7 @@ type Query7[A any, B any, C any, D any, E any, F any, G any] struct {
 	components []*componentStorage
 	cursor     cursor
 	lock       uint8
-	lastComp   uint8
+	rareComp   uint8
 }
 
 // GetRelation returns the entity relation target of the component at the given index.
@@ -959,7 +959,7 @@ func (q *Query7[A, B, C, D, E, F, G]) nextTableOrArchetype() bool {
 
 func (q *Query7[A, B, C, D, E, F, G]) nextArchetype() bool {
 	q.tables = nil
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {
 		q.cursor.archetype++
@@ -1045,7 +1045,7 @@ type Query8[A any, B any, C any, D any, E any, F any, G any, H any] struct {
 	components []*componentStorage
 	cursor     cursor
 	lock       uint8
-	lastComp   uint8
+	rareComp   uint8
 }
 
 // GetRelation returns the entity relation target of the component at the given index.
@@ -1099,7 +1099,7 @@ func (q *Query8[A, B, C, D, E, F, G, H]) nextTableOrArchetype() bool {
 
 func (q *Query8[A, B, C, D, E, F, G, H]) nextArchetype() bool {
 	q.tables = nil
-	archetypes := q.world.storage.archetypesMap[q.lastComp]
+	archetypes := q.world.storage.archetypesMap[q.rareComp]
 	maxArchIndex := int32(len(archetypes) - 1)
 	for q.cursor.archetype < maxArchIndex {
 		q.cursor.archetype++

--- a/ecs/registry.go
+++ b/ecs/registry.go
@@ -14,6 +14,7 @@ type registry struct {
 	Used       bitMask                // Mapping from IDs to used status.
 	Trivial    bitMask                // Mapping from IDs to whether types are trivial.
 	Archetypes []int                  // Number of archetypes for each component.
+	generation int
 }
 
 // newComponentRegistry creates a new ComponentRegistry.
@@ -24,6 +25,7 @@ func newRegistry() registry {
 		Used:       bitMask{},
 		IDs:        []uint8{},
 		Archetypes: make([]int, maskTotalBits),
+		generation: 1,
 	}
 }
 
@@ -72,6 +74,11 @@ func (r *registry) unregisterLastComponent() {
 
 func (r *registry) addArchetype(id uint8) {
 	r.Archetypes[id]++
+	r.generation++
+}
+
+func (r *registry) getGeneration() int {
+	return r.generation
 }
 
 // Returns the ID of the component present in the smallest number of archetypes.

--- a/ecs/registry.go
+++ b/ecs/registry.go
@@ -74,7 +74,8 @@ func (r *registry) addArchetype(id uint8) {
 	r.Archetypes[id]++
 }
 
-func (r *registry) rareArchetype(ids []ID) ID {
+// Returns the ID of the component present in the smallest number of archetypes.
+func (r *registry) rareComponent(ids []ID) ID {
 	minCount := math.MaxInt
 	var rareID ID
 	for _, id := range ids {

--- a/ecs/registry_test.go
+++ b/ecs/registry_test.go
@@ -44,6 +44,36 @@ func TestComponentRegistryOverflow(t *testing.T) {
 	})
 }
 
+func TestAddArchetype(t *testing.T) {
+	reg := newComponentRegistry()
+
+	id0 := reg.registerComponent(reflect.TypeOf((*Position)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*Velocity)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*Heading)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*ChildOf)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*ChildOf2)(nil)).Elem(), maskTotalBits)
+
+	reg.addArchetype(id0)
+
+	assert.Equal(t, maskTotalBits, len(reg.Archetypes))
+	assert.Equal(t, []int{1, 0}, reg.Archetypes[:2])
+}
+
+func TestRareArchetype(t *testing.T) {
+	reg := newComponentRegistry()
+
+	id0 := reg.registerComponent(reflect.TypeOf((*Position)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*Velocity)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*Heading)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*ChildOf)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*ChildOf2)(nil)).Elem(), maskTotalBits)
+
+	reg.addArchetype(id0)
+
+	assert.Equal(t, ID{1}, reg.rareArchetype([]ID{{0}, {1}}))
+	assert.Equal(t, ID{1}, reg.rareArchetype([]ID{{1}, {0}}))
+}
+
 func BenchmarkRegistryGet(b *testing.B) {
 	w := NewWorld(1024)
 
@@ -61,5 +91,39 @@ func BenchmarkTypeEquality(b *testing.B) {
 
 	for b.Loop() {
 		_ = tp1 == tp2
+	}
+}
+
+func BenchmarkRareArchetype2(b *testing.B) {
+	reg := newComponentRegistry()
+
+	id0 := reg.registerComponent(reflect.TypeOf((*Position)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*Velocity)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*Heading)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*ChildOf)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*ChildOf2)(nil)).Elem(), maskTotalBits)
+
+	reg.addArchetype(id0)
+	ids := []ID{{0}, {1}}
+
+	for b.Loop() {
+		reg.rareArchetype(ids)
+	}
+}
+
+func BenchmarkRareArchetype5(b *testing.B) {
+	reg := newComponentRegistry()
+
+	id0 := reg.registerComponent(reflect.TypeOf((*Position)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*Velocity)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*Heading)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*ChildOf)(nil)).Elem(), maskTotalBits)
+	reg.registerComponent(reflect.TypeOf((*ChildOf2)(nil)).Elem(), maskTotalBits)
+
+	reg.addArchetype(id0)
+	ids := []ID{{0}, {1}, {2}, {3}, {4}}
+
+	for b.Loop() {
+		reg.rareArchetype(ids)
 	}
 }

--- a/ecs/registry_test.go
+++ b/ecs/registry_test.go
@@ -59,7 +59,7 @@ func TestAddArchetype(t *testing.T) {
 	assert.Equal(t, []int{1, 0}, reg.Archetypes[:2])
 }
 
-func TestRareArchetype(t *testing.T) {
+func TestRareComponent(t *testing.T) {
 	reg := newComponentRegistry()
 
 	id0 := reg.registerComponent(reflect.TypeOf((*Position)(nil)).Elem(), maskTotalBits)
@@ -70,8 +70,8 @@ func TestRareArchetype(t *testing.T) {
 
 	reg.addArchetype(id0)
 
-	assert.Equal(t, ID{1}, reg.rareArchetype([]ID{{0}, {1}}))
-	assert.Equal(t, ID{1}, reg.rareArchetype([]ID{{1}, {0}}))
+	assert.Equal(t, ID{1}, reg.rareComponent([]ID{{0}, {1}}))
+	assert.Equal(t, ID{1}, reg.rareComponent([]ID{{1}, {0}}))
 }
 
 func BenchmarkRegistryGet(b *testing.B) {
@@ -94,7 +94,7 @@ func BenchmarkTypeEquality(b *testing.B) {
 	}
 }
 
-func BenchmarkRareArchetype2(b *testing.B) {
+func BenchmarkRareComponent2(b *testing.B) {
 	reg := newComponentRegistry()
 
 	id0 := reg.registerComponent(reflect.TypeOf((*Position)(nil)).Elem(), maskTotalBits)
@@ -107,11 +107,11 @@ func BenchmarkRareArchetype2(b *testing.B) {
 	ids := []ID{{0}, {1}}
 
 	for b.Loop() {
-		reg.rareArchetype(ids)
+		reg.rareComponent(ids)
 	}
 }
 
-func BenchmarkRareArchetype5(b *testing.B) {
+func BenchmarkRareComponent5(b *testing.B) {
 	reg := newComponentRegistry()
 
 	id0 := reg.registerComponent(reflect.TypeOf((*Position)(nil)).Elem(), maskTotalBits)
@@ -124,6 +124,6 @@ func BenchmarkRareArchetype5(b *testing.B) {
 	ids := []ID{{0}, {1}, {2}, {3}, {4}}
 
 	for b.Loop() {
-		reg.rareArchetype(ids)
+		reg.rareComponent(ids)
 	}
 }

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -223,6 +223,7 @@ func (s *storage) createArchetype(node *node) *archetype {
 
 	for _, id := range archetype.components {
 		s.archetypesMap[id.id] = append(s.archetypesMap[id.id], archetype)
+		s.registry.addArchetype(id.id)
 	}
 	if archetype.HasRelations() {
 		s.relationArchetypes = append(s.relationArchetypes, archetype.id)


### PR DESCRIPTION
Select the most "rare" component automatically instead of relying on the last query parameter.
Updates/recalculates rare component only on changed registry.