### PR TITLE
Use uint32 for cache and observer IDs

### DIFF
--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -2,9 +2,9 @@ package ecs
 
 import "math"
 
-type cacheID uint16
+type cacheID uint32
 
-const maxCacheID = math.MaxUint16
+const maxCacheID = math.MaxUint32
 
 // Cache entry for a filter.
 type cacheEntry struct {

--- a/ecs/events.go
+++ b/ecs/events.go
@@ -4,9 +4,9 @@ import (
 	"math"
 )
 
-type observerID uint16
+type observerID uint32
 
-const maxObserverID = math.MaxUint16
+const maxObserverID = math.MaxUint32
 
 // EventType is the type for event identifiers.
 // See [Observer] for details on events.


### PR DESCRIPTION
Fixes #337 