### PR TITLE
Custom events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Features
 
-- Adds an event system for ECS operations, like entity creation/removal and component addition/removal (#330, #331, #333, #342)
-- Adds generic observers for direct component access (#344)
+- Adds an event system for ECS operations, like entity creation/removal and component addition/removal (#330, #331, #333, #342, #344)
+- Adds custom event support for the event system (#340)
 - Adds method `World.Shrink` for freeing memory that exceeds current requirements (#323)
 
 ### Performance

--- a/ecs/events.go
+++ b/ecs/events.go
@@ -361,7 +361,7 @@ func NewEvent(e EventType, world *World) Event {
 
 // For sets the event's component types. Optional.
 // For best performance, store the event after setting the component type,
-// and re-use afterwards be overwriting the entity.
+// and re-use afterwards.
 func (e Event) For(comps ...Comp) Event {
 	for i := range comps {
 		id := TypeID(e.world, comps[i].tp)

--- a/ecs/events.go
+++ b/ecs/events.go
@@ -39,16 +39,15 @@ const (
 	eventsEnd
 )
 
-var nextUserEvent = eventsEnd
+var nextUserEvent = eventsEnd - 1
 
 // NewEventType creates a new EventType for custom events.
 func NewEventType() EventType {
 	if nextUserEvent == math.MaxUint8 {
 		panic("reached maximum number of custom event types")
 	}
-	e := EventType(nextUserEvent)
 	nextUserEvent++
-	return e
+	return EventType(nextUserEvent)
 }
 
 type observerManager struct {

--- a/ecs/events.go
+++ b/ecs/events.go
@@ -315,7 +315,7 @@ func (m *observerManager) FireCustom(evt EventType, e Entity, mask, entityMask *
 }
 
 func (m *observerManager) doFireCustom(evt EventType, e Entity, mask, entityMask *bitMask) {
-	if !m.anyNoComps[evt] && !m.allComps[OnSetComponents].ContainsAny(mask) {
+	if !m.anyNoComps[evt] && !m.allComps[evt].ContainsAny(mask) {
 		return
 	}
 	if !m.anyNoWith[evt] && !m.allWith[evt].ContainsAny(entityMask) {

--- a/ecs/events.go
+++ b/ecs/events.go
@@ -9,10 +9,13 @@ type observerID uint32
 const maxObserverID = math.MaxUint32
 
 // EventType is the type for event identifiers.
+// Use [NewEventType] to create custom events types.
+// See below for predefined event types.
 //
 // See [Observer] for details on events and observers.
 type EventType uint8
 
+// Predefined event types.
 const (
 
 	// OnCreateEntity event.
@@ -42,6 +45,9 @@ const (
 var nextUserEvent = eventsEnd - 1
 
 // NewEventType creates a new EventType for custom events.
+// Custom event types should be stored in global variables.
+//
+// The maximum number of event types is 255, with 5 predefined and 250 potential custom types.
 func NewEventType() EventType {
 	if nextUserEvent == math.MaxUint8 {
 		panic("reached maximum number of custom event types")

--- a/ecs/events.go
+++ b/ecs/events.go
@@ -307,18 +307,18 @@ func (m *observerManager) doFireSet(e Entity, mask *bitMask, newMask *bitMask) {
 	}
 }
 
-func (m *observerManager) FireCustom(evt EventType, e Entity, comp ID, hasComp bool, mask *bitMask) {
+func (m *observerManager) FireCustom(evt EventType, e Entity, comp ID, hasComp bool, entityMask *bitMask) {
 	if !m.hasObservers[evt] {
 		return
 	}
-	m.doFireCustom(evt, e, comp, hasComp, mask)
+	m.doFireCustom(evt, e, comp, hasComp, entityMask)
 }
 
-func (m *observerManager) doFireCustom(evt EventType, e Entity, comp ID, hasComp bool, mask *bitMask) {
+func (m *observerManager) doFireCustom(evt EventType, e Entity, comp ID, hasComp bool, entityMask *bitMask) {
 	if !m.anyNoComps[evt] && (!hasComp || !m.allComps[evt].Get(comp.id)) {
 		return
 	}
-	if !m.anyNoWith[evt] && !m.allWith[evt].ContainsAny(mask) {
+	if !m.anyNoWith[evt] && !m.allWith[evt].ContainsAny(entityMask) {
 		return
 	}
 	observers := m.observers[evt]
@@ -329,10 +329,10 @@ func (m *observerManager) doFireCustom(evt EventType, e Entity, comp ID, hasComp
 		if o.hasComps && !hasComp {
 			continue
 		}
-		if o.hasWith && !mask.Contains(&o.withMask) {
+		if o.hasWith && !entityMask.Contains(&o.withMask) {
 			continue
 		}
-		if o.hasWithout && mask.ContainsAny(&o.withoutMask) {
+		if o.hasWithout && entityMask.ContainsAny(&o.withoutMask) {
 			continue
 		}
 		o.callback(e)

--- a/ecs/events_test.go
+++ b/ecs/events_test.go
@@ -8,6 +8,7 @@ import (
 func TestCustomEvent(t *testing.T) {
 	world := NewWorld()
 	customEvent := NewEventType()
+	builder := NewMap2[Position, Velocity](&world)
 
 	callCount := 0
 	Observe(customEvent).
@@ -15,7 +16,7 @@ func TestCustomEvent(t *testing.T) {
 		Do(func(e Entity) { callCount++ }).
 		Register(&world)
 
-	e := world.NewEntity()
+	e := builder.NewEntity(&Position{1, 2}, &Velocity{3, 4})
 
 	evt := NewEvent(customEvent, &world).For(C[Position]())
 
@@ -44,4 +45,24 @@ func TestCustomEventGeneric(t *testing.T) {
 
 	evt := NewEvent(customEvent, &world).For(C[Position]())
 	evt.Emit(e)
+	expectEqual(t, 1, callCount)
+}
+
+func TestCustomEventEmpty(t *testing.T) {
+	world := NewWorld()
+	customEvent := NewEventType()
+	builder := NewMap2[Position, Velocity](&world)
+
+	callCount := 0
+	Observe(customEvent).
+		Do(func(e Entity) {
+			callCount++
+		}).
+		Register(&world)
+
+	e := builder.NewEntity(&Position{1, 2}, &Velocity{3, 4})
+
+	evt := NewEvent(customEvent, &world)
+	evt.Emit(e)
+	expectEqual(t, 1, callCount)
 }

--- a/ecs/events_test.go
+++ b/ecs/events_test.go
@@ -1,0 +1,48 @@
+package ecs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCustomEvent(t *testing.T) {
+	world := NewWorld()
+	customEvent := NewEventType()
+
+	callCount := 0
+	Observe(customEvent).
+		For(C[Position]()).
+		Do(func(e Entity) { callCount++ }).
+		Register(&world)
+
+	e := world.NewEntity()
+
+	evt := NewEvent(customEvent, &world).For(C[Position]())
+	expectTrue(t, evt.hasComp)
+
+	evt.Emit(e)
+	expectEqual(t, 1, callCount)
+	NewEvent(customEvent, &world).For(C[Velocity]()).Emit(e)
+	expectEqual(t, 1, callCount)
+	evt.Emit(e)
+	expectEqual(t, 2, callCount)
+}
+
+func TestCustomEventGeneric(t *testing.T) {
+	world := NewWorld()
+	customEvent := NewEventType()
+	builder := NewMap2[Position, Velocity](&world)
+
+	callCount := 0
+	Observe1[Position](customEvent).
+		Do(func(e Entity, pos *Position) {
+			callCount++
+			fmt.Printf("%#v", pos)
+		}).
+		Register(&world)
+
+	e := builder.NewEntity(&Position{1, 2}, &Velocity{3, 4})
+
+	evt := NewEvent(customEvent, &world).For(C[Position]())
+	evt.Emit(e)
+}

--- a/ecs/events_test.go
+++ b/ecs/events_test.go
@@ -18,7 +18,6 @@ func TestCustomEvent(t *testing.T) {
 	e := world.NewEntity()
 
 	evt := NewEvent(customEvent, &world).For(C[Position]())
-	expectTrue(t, evt.hasComp)
 
 	evt.Emit(e)
 	expectEqual(t, 1, callCount)

--- a/ecs/events_test.go
+++ b/ecs/events_test.go
@@ -122,3 +122,35 @@ func TestCustomEventErrors(t *testing.T) {
 			NewEvent(customEvent, &world).Emit(e)
 		})
 }
+
+func BenchmarkEventEmit(b *testing.B) {
+	w := NewWorld()
+	builder := NewMap1[Position](&w)
+	e := builder.NewEntity(&Position{})
+
+	evt := NewEvent(customEvent, &w)
+
+	for b.Loop() {
+		evt.Emit(e)
+	}
+}
+
+func BenchmarkEventCreateEmit(b *testing.B) {
+	w := NewWorld()
+	builder := NewMap1[Position](&w)
+	e := builder.NewEntity(&Position{})
+
+	for b.Loop() {
+		NewEvent(customEvent, &w).Emit(e)
+	}
+}
+
+func BenchmarkEventCreateForEmit(b *testing.B) {
+	w := NewWorld()
+	builder := NewMap1[Position](&w)
+	e := builder.NewEntity(&Position{})
+
+	for b.Loop() {
+		NewEvent(customEvent, &w).For(C[Position]()).Emit(e)
+	}
+}

--- a/ecs/observer_test.go
+++ b/ecs/observer_test.go
@@ -636,29 +636,6 @@ func TestObserverWildcardEntities(t *testing.T) {
 	expectEqual(t, 2, callRemove)
 }
 
-func TestCustomEvent(t *testing.T) {
-	world := NewWorld()
-	customEvent := NewEventType()
-
-	callCount := 0
-	Observe(customEvent).
-		For(C[Position]()).
-		Do(func(e Entity) { callCount++ }).
-		Register(&world)
-
-	e := world.NewEntity()
-
-	evt := NewEvent(customEvent, &world).For(C[Position]())
-	expectTrue(t, evt.hasComp)
-
-	evt.Emit(e)
-	expectEqual(t, 1, callCount)
-	NewEvent(customEvent, &world).For(C[Velocity]()).Emit(e)
-	expectEqual(t, 1, callCount)
-	evt.Emit(e)
-	expectEqual(t, 2, callCount)
-}
-
 func benchmarkEventsPos(b *testing.B, n int) {
 	w := NewWorld()
 

--- a/ecs/observer_test.go
+++ b/ecs/observer_test.go
@@ -636,6 +636,29 @@ func TestObserverWildcardEntities(t *testing.T) {
 	expectEqual(t, 2, callRemove)
 }
 
+func TestCustomEvent(t *testing.T) {
+	world := NewWorld()
+	customEvent := NewEventType()
+
+	callCount := 0
+	Observe(customEvent).
+		For(C[Position]()).
+		Do(func(e Entity) { callCount++ }).
+		Register(&world)
+
+	e := world.NewEntity()
+
+	evt := NewEvent(customEvent, &world).For(C[Position]())
+	expectTrue(t, evt.hasComp)
+
+	evt.Emit(e)
+	expectEqual(t, 1, callCount)
+	NewEvent(customEvent, &world).For(C[Velocity]()).Emit(e)
+	expectEqual(t, 1, callCount)
+	evt.Emit(e)
+	expectEqual(t, 2, callCount)
+}
+
 func benchmarkEventsPos(b *testing.B, n int) {
 	w := NewWorld()
 

--- a/ecs/observer_test.go
+++ b/ecs/observer_test.go
@@ -636,6 +636,31 @@ func TestObserverWildcardEntities(t *testing.T) {
 	expectEqual(t, 2, callRemove)
 }
 
+func TestObserverCustomEvents(t *testing.T) {
+	w := NewWorld()
+	builder := NewMap1[Position](&w)
+
+	e1 := w.NewEntity()
+	e2 := builder.NewEntity(&Position{})
+
+	NewEvent(customEvent, &w).Emit(e1)
+
+	callCount := 0
+
+	obs := Observe(customEvent).With(comp[Position]()).Do(func(e Entity) { callCount++ }).Register(&w)
+	NewEvent(customEvent, &w).Emit(e1)
+	obs.Unregister(&w)
+
+	Observe(customEvent).Do(func(e Entity) { callCount++ }).Register(&w)
+	Observe(customEvent).For(C[Position]()).Do(func(e Entity) { callCount++ }).Register(&w)
+	Observe(customEvent).With(C[Position]()).Do(func(e Entity) { callCount++ }).Register(&w)
+	Observe(customEvent).Without(C[Position]()).Do(func(e Entity) { callCount++ }).Register(&w)
+	NewEvent(customEvent, &w).Emit(e1)
+	NewEvent(customEvent, &w).Emit(e2)
+
+	expectEqual(t, 4, callCount)
+}
+
 func benchmarkEventsPos(b *testing.B, n int) {
 	w := NewWorld()
 

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -1,7 +1,6 @@
 package ecs
 
 import (
-	"fmt"
 	"reflect"
 )
 
@@ -344,8 +343,8 @@ func (w *World) emitEvent(e *Event, entity Entity) {
 		table := w.storage.entities[entity.id].table
 		mask = &w.storage.archetypes[w.storage.tables[table].archetype].mask
 	}
-	if e.hasComp && !mask.Get(e.component.id) {
-		panic(fmt.Sprintf("event entity does not have component with ID %d", e.component.id))
+	if !mask.Contains(&e.mask) {
+		panic("entity does not have the required components")
 	}
-	w.storage.observers.FireCustom(e.eventType, entity, e.component, e.hasComp, mask)
+	w.storage.observers.FireCustom(e.eventType, entity, &e.mask, mask)
 }

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -344,7 +344,7 @@ func (w *World) emitEvent(e *Event, entity Entity) {
 		mask = &w.storage.archetypes[w.storage.tables[table].archetype].mask
 	}
 	if !mask.Contains(&e.mask) {
-		panic("entity does not have the required components")
+		panic("entity does not have the required event components")
 	}
 	w.storage.observers.FireCustom(e.eventType, entity, &e.mask, mask)
 }

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -331,3 +331,17 @@ func (w *World) checkLocked() {
 		panic("cannot modify a locked world: collect entities into a slice and apply changes after query iteration has completed")
 	}
 }
+
+func (w *World) emitEvent(e *Event, entity Entity) {
+	var mask *bitMask
+	if entity.IsZero() {
+		mask = &w.storage.archetypes[0].mask
+	} else {
+		if !w.Alive(entity) {
+			panic("can't emit an event for a dead entity")
+		}
+		table := w.storage.entities[entity.id].table
+		mask = &w.storage.archetypes[w.storage.tables[table].archetype].mask
+	}
+	w.storage.observers.FireCustom(e.eventType, entity, e.component, e.hasComp, mask)
+}

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"fmt"
 	"reflect"
 )
 
@@ -342,6 +343,9 @@ func (w *World) emitEvent(e *Event, entity Entity) {
 		}
 		table := w.storage.entities[entity.id].table
 		mask = &w.storage.archetypes[w.storage.tables[table].archetype].mask
+	}
+	if e.hasComp && !mask.Get(e.component.id) {
+		panic(fmt.Sprintf("event entity does not have component with ID %d", e.component.id))
 	}
 	w.storage.observers.FireCustom(e.eventType, entity, e.component, e.hasComp, mask)
 }


### PR DESCRIPTION
Example:

```go
onComponentUpdated := ecs.NewEventType()

ecs.Observe1[Position](onComponentUpdated).
    Do(func(e Entity, pos *Position) { /* ... */ }).
    Register(&world)

evt := NewEvent(onComponentUpdated, &world).For(C[Position]())
evt.Emit(entity)
```

Without component:

```go
onClick := ecs.NewEventType()

ecs.Observe(onClick).
    Do(func(e Entity) { /* ... */ }).
    Register(&world)

evt := NewEvent(onClick, &world)
evt.Emit(uiEntity)
```

Fixes #336 